### PR TITLE
issue1: A java compile task that activates the default Querydsl annotati...

### DIFF
--- a/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/QuerydslPlugin.groovy
+++ b/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/QuerydslPlugin.groovy
@@ -63,6 +63,7 @@ class QuerydslPlugin implements Plugin<Project> {
       morphiaTask(project)
       rooTask(project)
       springDataMongoTask(project)
+      querydslDefaultTask(project)
 
       File querydslSourcesDir = querydslSourcesDir(project)
 
@@ -117,6 +118,14 @@ class QuerydslPlugin implements Plugin<Project> {
       project.task(type: CompileQuerydslSpringDataMongo, "compileQuerydslSpringDataMongo")
       project.tasks.compileQuerydslSpringDataMongo.dependsOn project.tasks.initQuerydslSourcesDir
       project.tasks.compileJava.dependsOn project.tasks.compileQuerydslSpringDataMongo
+    }
+  }
+
+  private static void querydslDefaultTask(Project project) {
+    if (project.extensions.querydsl.querydslDefault) {
+      project.task(type: CompileQuerydslDefault, "compileQuerydslDefault")
+      project.tasks.compileQuerydslDefault.dependsOn project.tasks.initQuerydslSourcesDir
+      project.tasks.compileJava.dependsOn project.tasks.compileQuerydslDefault
     }
   }
 

--- a/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/QuerydslPluginExtension.groovy
+++ b/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/QuerydslPluginExtension.groovy
@@ -22,4 +22,6 @@ class QuerydslPluginExtension {
   boolean morphia = false;
   boolean roo = false;
   boolean springDataMongo = false;
+  boolean querydslDefault = false;
+
 }

--- a/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/CompileQuerydslDefault.groovy
+++ b/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/CompileQuerydslDefault.groovy
@@ -1,0 +1,16 @@
+package com.ewerk.gradle.plugins.tasks
+
+/**
+ * A java compile task that activates the default Querydsl annotation processor.
+ * @author griffio
+ * @since 1.0.2
+ */
+class CompileQuerydslDefault extends AbstractCompileQuerydsl {
+
+  public static final String PROCESSOR = "com.mysema.query.apt.QuerydslAnnotationProcessor"
+
+  @Override
+  String processor() {
+    return PROCESSOR
+  }
+}

--- a/querydsl-plugin/src/test/groovy/com/ewerk/gradle/plugins/QuerydslPluginTest.groovy
+++ b/querydsl-plugin/src/test/groovy/com/ewerk/gradle/plugins/QuerydslPluginTest.groovy
@@ -30,6 +30,7 @@ class QuerydslPluginTest {
     project.extensions.querydsl.hibernate = true;
     project.extensions.querydsl.morphia = true;
     project.extensions.querydsl.springDataMongo = true;
+    project.extensions.querydsl.querydslDefault = true;
   }
 
   @Test
@@ -84,5 +85,6 @@ class QuerydslPluginTest {
     assertThat(project.tasks.compileQuerydslRoo, notNullValue())
     assertThat(project.tasks.compileQuerydslMorphia, notNullValue())
     assertThat(project.tasks.compileQuerydslSpringDataMongo, notNullValue())
+    assertThat(project.tasks.compileQuerydslDefault, notNullValue())
   }
 }


### PR DESCRIPTION
...on processor

Naming of flag is querydslDefault: "default" is a reserved word and "querydsl" is name of the existing groovy task so cannot use either individually in a build script.

Tested with local Sample Application 

Signed-off-by: griffio <griffio@users.noreply.github.com>