### PR TITLE
Configure compile task not after evaluate	

### DIFF
--- a/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/QuerydslPlugin.groovy
+++ b/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/QuerydslPlugin.groovy
@@ -55,12 +55,11 @@ class QuerydslPlugin implements Plugin<Project> {
     // make 'clean' depend clean ing querydsl sources
     project.tasks.clean.dependsOn project.tasks.cleanQuerydslSourcesDir
 
+    project.task(type: QuerydslCompile, "compileQuerydsl")
+    project.tasks.compileQuerydsl.dependsOn project.tasks.initQuerydslSourcesDir
+    project.tasks.compileJava.dependsOn project.tasks.compileQuerydsl
+
     project.afterEvaluate {
-
-      project.task(type: QuerydslCompile, "compileQuerydsl")
-      project.tasks.compileQuerydsl.dependsOn project.tasks.initQuerydslSourcesDir
-      project.tasks.compileJava.dependsOn project.tasks.compileQuerydsl
-
       File querydslSourcesDir = querydslSourcesDir(project)
 
       addLibrary(project)

--- a/querydsl-plugin/src/test/groovy/com/ewerk/gradle/plugins/tasks/QuerydslCompileTest.groovy
+++ b/querydsl-plugin/src/test/groovy/com/ewerk/gradle/plugins/tasks/QuerydslCompileTest.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.ewerk.gradle.plugins.tasks;
 
 import static org.hamcrest.CoreMatchers.hasItem
@@ -11,11 +26,14 @@ import org.junit.Test
 
 import com.ewerk.gradle.plugins.QuerydslPlugin
 
+/**
+ * @author Illya Boyko
+ */
 public class QuerydslCompileTest {
+
     private Project project;
 
     private SourceTask compileTask;
-
 
     public QuerydslCompileTest() {
 	project = ProjectBuilder.builder().build();
@@ -23,12 +41,11 @@ public class QuerydslCompileTest {
 	compileTask = project.tasks.compileQuerydsl as SourceTask
 	compileTask.includes += ['**/entities/*.java']
 	project.evaluate()
-
 	
     }
     
     @Test
-    void tesIncludes() {
+    void testIncludes() {
 	def includes = compileTask.getIncludes()
 	assertThat(compileTask.getIncludes(), hasItem(is('**/entities/*.java')))
     }

--- a/querydsl-plugin/src/test/groovy/com/ewerk/gradle/plugins/tasks/QuerydslCompileTest.groovy
+++ b/querydsl-plugin/src/test/groovy/com/ewerk/gradle/plugins/tasks/QuerydslCompileTest.groovy
@@ -1,0 +1,35 @@
+package com.ewerk.gradle.plugins.tasks;
+
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.is
+import static org.junit.Assert.*
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceTask
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+import com.ewerk.gradle.plugins.QuerydslPlugin
+
+public class QuerydslCompileTest {
+    private Project project;
+
+    private SourceTask compileTask;
+
+
+    public QuerydslCompileTest() {
+	project = ProjectBuilder.builder().build();
+	project.plugins.apply(QuerydslPlugin.class)
+	compileTask = project.tasks.compileQuerydsl as SourceTask
+	compileTask.includes += ['**/entities/*.java']
+	project.evaluate()
+
+	
+    }
+    
+    @Test
+    void tesIncludes() {
+	def includes = compileTask.getIncludes()
+	assertThat(compileTask.getIncludes(), hasItem(is('**/entities/*.java')))
+    }
+}


### PR DESCRIPTION
This allows to use SourceTask features such as *includes*. 
*compileQuerydsl* can be configured directly in Gradle build script.

```groovy
compileQuerydsl {
   includes += ['**/entities/*.java']
}
```