### PR TITLE
Dagger2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 **/*.iml
 **/.gradle/
 **/src/auto-value/**
+**/src/dagger/**
 **/src/querydsl/**
 hs_err_*.log
+classes

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The plugins are based on Gradle ≥ 2.1.
 * [auto-value-plugin] (https://github.com/ewerk/gradle-plugins/tree/master/auto-value-plugin)
 * [integration-test-plugin] (https://github.com/ewerk/gradle-plugins/tree/master/integration-test-plugin)
 * [querydsl-plugin] (https://github.com/ewerk/gradle-plugins/tree/master/querydsl-plugin)
+* [dagger-plugin] (Incubating, pull request in preparation)
 
 Please have a look at the `sample-application` module providing a code example on how to use the
 plugins.

--- a/dagger-plugin/build.gradle
+++ b/dagger-plugin/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+  id "maven"
+  id "net.researchgate.release" version "2.0.2"
+  id "com.gradle.plugin-publish" version "0.9.0"
+}
+
+pluginBundle {
+  website = 'http://www.ewerk.com'
+  vcsUrl = 'https://github.com/ewerk/gradle-plugins'
+  description = 'Plugin for generating Dagger2 Java source'
+  tags = ['dagger2']
+
+  plugins {
+    daggerPlugin {
+      id = 'com.ewerk.gradle.plugins.dagger'
+      displayName = 'Gradle Daggger2 plugin'
+    }
+  }
+}
+
+dependencies {
+  compile gradleApi()
+  compile localGroovy()
+}
+
+test {
+  useTestNG()
+  minHeapSize = "128m"
+  maxHeapSize = "512m"
+}
+
+release {
+  tagPrefix = "dagger-plugin"
+  requireBranch = "release"
+}
+
+createReleaseTag.dependsOn("check")

--- a/dagger-plugin/change_log.md
+++ b/dagger-plugin/change_log.md
@@ -1,0 +1,4 @@
+# Change log
+
+## 1.0.0
+* Initial release

--- a/dagger-plugin/gradle.properties
+++ b/dagger-plugin/gradle.properties
@@ -1,0 +1,1 @@
+version=1.0.0-SNAPSHOT

--- a/dagger-plugin/readme.md
+++ b/dagger-plugin/readme.md
@@ -2,6 +2,62 @@
 
 #### Description
 
+"Dagger2 dependency injection - The guiding principle is to generate code that mimics the code that a user might have hand-written."
+
 This plugin uses the [Dagger2](http://google.github.io/dagger/) compiler.
 
-[This plugins change log] (change_log.md).
+[This plugins change log](change_log.md).
+
+#### Configuration
+
+##### daggerSourcesDir
+
+The destination directory for the generated Dagger java source
+Defaults to 'src/dagger/java'.
+
+##### library
+
+The dependency artifact for the compile/runtime usage of Dagger.
+This is added to the compile configuration for the project.
+
+Defaults to 'com.google.dagger:dagger:2.0'.
+
+##### processorLibrary
+
+The dependency artifact for the compile/runtime usage of Dagger.
+Defaults to 'com.google.dagger:dagger-compiler:2.0'.
+
+#### Examples
+
+__Use via Gradle plugin portal__
+
+```groovy
+plugins {
+  id "com.ewerk.gradle.plugins.dagger" version "1.0.0"
+}
+```
+
+__Use via JCenter__
+
+```groovy
+buildscript {
+  repositories {
+    jcenter()
+  }
+
+  dependencies {
+    classpath "com.ewerk.gradle.plugins:dagger-plugin:1.0.0"
+  }
+}
+
+apply plugin: 'com.ewerk.gradle.plugins.dagger'
+```
+
+```groovy
+// the following closure demonstrates some of the configuration defaults and is not necessary
+dagger {
+  library = "com.google.dagger:dagger:2.0"
+  processorLibrary = "com.google.dagger:dagger-compiler:2.0"
+  daggerSourcesDir = "src/dagger/java"
+}
+```

--- a/dagger-plugin/readme.md
+++ b/dagger-plugin/readme.md
@@ -4,4 +4,4 @@
 
 This plugin uses the [Dagger2](http://google.github.io/dagger/) compiler.
 
-Please have a look at the plugins [change log](change_log.md).
+[This plugins change log] (change_log.md).

--- a/dagger-plugin/readme.md
+++ b/dagger-plugin/readme.md
@@ -1,0 +1,7 @@
+### Dagger plugin
+
+#### Description
+
+This plugin uses the [Dagger2](http://google.github.io/dagger/) compiler.
+
+Please have a look at the plugins [change log](change_log.md).

--- a/dagger-plugin/readme.md
+++ b/dagger-plugin/readme.md
@@ -4,7 +4,7 @@
 
 "Dagger2 dependency injection - The guiding principle is to generate code that mimics the code that a user might have hand-written."
 
-This plugin uses the [Dagger2](http://google.github.io/dagger/) compiler.
+This plugin uses the [Dagger2](http://google.github.io/dagger/) compiler to process annotations that are compatible with JSR-330.
 
 [This plugins change log](change_log.md).
 
@@ -12,7 +12,8 @@ This plugin uses the [Dagger2](http://google.github.io/dagger/) compiler.
 
 ##### daggerSourcesDir
 
-The destination directory for the generated Dagger java source
+The destination directory for the generated Dagger java source.
+
 Defaults to 'src/dagger/java'.
 
 ##### library
@@ -25,6 +26,7 @@ Defaults to 'com.google.dagger:dagger:2.0'.
 ##### processorLibrary
 
 The dependency artifact for the compile/runtime usage of Dagger.
+
 Defaults to 'com.google.dagger:dagger-compiler:2.0'.
 
 #### Examples

--- a/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPlugin.groovy
+++ b/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPlugin.groovy
@@ -1,0 +1,86 @@
+package com.ewerk.gradle.plugins
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.plugins.WarPlugin
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.compile.JavaCompile;
+
+/**
+ * Dagger2 compiler plugin (http://google.github.io/dagger/) is a library with a processor dependency and a
+ * compile transitive dependency for the generated code.
+ *
+ * The processor dependency is added to the main JavaCompile task and is executed by classpath discovery.
+ *
+ * @author griffio
+ */
+public class DaggerPlugin implements Plugin<Project> {
+
+  private static final Logger LOG = Logging.getLogger(DaggerPlugin.class)
+
+  @Override
+  public void apply(Project project) {
+
+    if (project.plugins.hasPlugin(DaggerPlugin.class)) {
+      return;
+    }
+
+    LOG.info("Applying Dagger plugin")
+
+    if (!project.plugins.hasPlugin(JavaPlugin.class)) {
+      project.plugins.apply(JavaPlugin.class)
+    }
+
+    if (project.plugins.hasPlugin(WarPlugin.class)) {
+      project.configurations {
+        dagger.extendsFrom compile, providedRuntime, providedCompile
+      }
+    } else {
+      project.configurations {
+        dagger.extendsFrom compile
+      }
+    }
+
+    project.extensions.create(DaggerPluginExtension.NAME, DaggerPluginExtension)
+
+    project.plugins.withType(JavaPlugin) {
+
+      def javaConvention = project.convention.plugins.get("java") as JavaPluginConvention
+
+      javaConvention.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME) { SourceSet sourceSet ->
+        LOG.info("task:" + sourceSet.getCompileJavaTaskName())
+        def compileTask = project.tasks.withType(JavaCompile).getByName(sourceSet.getCompileJavaTaskName())
+        compileTask.classpath += project.configurations.dagger
+        compileTask.options.compilerArgs += [
+            "-s", project.file(project.extensions.dagger.daggerSourcesDir).absolutePath
+        ]
+      }
+
+      javaConvention.sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME) { SourceSet sourceSet ->
+        LOG.info("task:" + sourceSet.getCompileJavaTaskName())
+      }
+
+    }
+
+    project.afterEvaluate {
+
+      project.dependencies {
+        dagger project.extensions.dagger.processorLibrary
+        compile project.extensions.dagger.library
+      }
+
+      project.sourceSets {
+        dagger {
+          java.srcDirs = [project.extensions.dagger.daggerSourcesDir]
+        }
+      }
+
+    }
+
+  }
+
+}

--- a/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPlugin.groovy
+++ b/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPlugin.groovy
@@ -72,6 +72,10 @@ public class DaggerPlugin implements Plugin<Project> {
         }
       }
 
+      project.compileJava {
+        source project.extensions.dagger.daggerSourcesDir
+      }
+
     }
 
   }

--- a/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPluginExtension.groovy
+++ b/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPluginExtension.groovy
@@ -2,6 +2,8 @@ package com.ewerk.gradle.plugins;
 
 /**
  * @author griffio
+ *
+ * Defines the default configuration parameters in the Plugin
  */
 public class DaggerPluginExtension {
 
@@ -9,6 +11,7 @@ public class DaggerPluginExtension {
   static final String DEFAULT_DAGGER_SOURCES_DIR = "src/dagger/java"
   static final String DEFAULT_PROCESSOR_LIBRARY = "com.google.dagger:dagger-compiler:2.0"
   static final String DEFAULT_LIBRARY = "com.google.dagger:dagger:2.0"
+  static final String PROCESSOR = "dagger.internal.codegen.ComponentProcessor"
 
   String daggerSourcesDir = DEFAULT_DAGGER_SOURCES_DIR
   String library = DEFAULT_LIBRARY

--- a/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPluginExtension.groovy
+++ b/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPluginExtension.groovy
@@ -1,0 +1,17 @@
+package com.ewerk.gradle.plugins;
+
+/**
+ * @author griffio
+ */
+public class DaggerPluginExtension {
+
+  static final String NAME = "dagger"
+  static final String DEFAULT_DAGGER_SOURCES_DIR = "src/dagger/java"
+  static final String DEFAULT_PROCESSOR_LIBRARY = "com.google.dagger:dagger-compiler:2.0"
+  static final String DEFAULT_LIBRARY = "com.google.dagger:dagger:2.0"
+
+  String daggerSourcesDir = DEFAULT_DAGGER_SOURCES_DIR
+  String library = DEFAULT_LIBRARY
+  String processorLibrary = DEFAULT_PROCESSOR_LIBRARY
+
+}

--- a/dagger-plugin/src/main/groovy/com/ewerk/gradle/tasks/CleanDaggerSourcesDir.groovy
+++ b/dagger-plugin/src/main/groovy/com/ewerk/gradle/tasks/CleanDaggerSourcesDir.groovy
@@ -1,0 +1,32 @@
+package com.ewerk.gradle.tasks
+
+import com.ewerk.gradle.plugins.DaggerPlugin
+import org.gradle.api.DefaultTask
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * @author griffio
+ */
+class CleanDaggerSourcesDir extends DefaultTask {
+
+  private static final Logger LOG = Logging.getLogger(CleanDaggerSourcesDir.class)
+
+  CleanDaggerSourcesDir() {
+    this.group = DaggerPlugin.TASK_GROUP
+    this.description = "Cleans the Dagger sources dir."
+  }
+
+  @SuppressWarnings("GroovyUnusedDeclaration")
+  @TaskAction
+  def cleanSourceFolders() {
+    LOG.info("clean Source")
+    project.sourceSets.dagger.java.srcDirs.each { dir ->
+      if (dir.exists()) {
+        dir.deleteDir()
+      }
+    }
+  }
+
+}

--- a/dagger-plugin/src/main/groovy/com/ewerk/gradle/tasks/DaggerCompile.groovy
+++ b/dagger-plugin/src/main/groovy/com/ewerk/gradle/tasks/DaggerCompile.groovy
@@ -1,0 +1,38 @@
+package com.ewerk.gradle.tasks
+
+import org.gradle.api.plugins.WarPlugin
+import org.gradle.api.tasks.compile.JavaCompile
+
+/**
+ * @author griffio
+ */
+class DaggerCompile extends JavaCompile {
+
+  DaggerCompile() {
+
+    setSource(project.sourceSets.main.java)
+
+    if (project.plugins.hasPlugin(WarPlugin.class)) {
+      project.configurations {
+        dagger.extendsFrom compile, providedRuntime, providedCompile
+      }
+    } else {
+      project.configurations {
+        dagger.extendsFrom compile
+      }
+    }
+
+    File file = project.file(project.dagger.daggerSourcesDir)
+
+    options.compilerArgs = [
+        "-proc:only",
+        "-s", file.absolutePath,
+        "-processor", project.dagger.PROCESSOR
+    ]
+
+    setClasspath(project.configurations.dagger)
+
+    setDestinationDir(file)
+  }
+
+}

--- a/dagger-plugin/src/main/groovy/com/ewerk/gradle/tasks/InitDaggerSourcesDir.groovy
+++ b/dagger-plugin/src/main/groovy/com/ewerk/gradle/tasks/InitDaggerSourcesDir.groovy
@@ -1,0 +1,28 @@
+package com.ewerk.gradle.tasks
+
+import com.ewerk.gradle.plugins.DaggerPlugin
+import org.gradle.api.DefaultTask
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * @author griffio
+ */
+class InitDaggerSourcesDir extends DefaultTask {
+
+  private static final Logger LOG = Logging.getLogger(InitDaggerSourcesDir.class)
+
+  InitDaggerSourcesDir() {
+    this.group = DaggerPlugin.TASK_GROUP
+    this.description = "Creates the Dagger sources dir"
+  }
+
+  @SuppressWarnings("GroovyUnusedDeclaration")
+  @TaskAction
+  def createSourceFolders() {
+    LOG.info("create source")
+    project.file(project.dagger.daggerSourcesDir).mkdirs()
+  }
+
+}

--- a/dagger-plugin/src/main/resources/META-INF/gradle-plugins/com.ewerk.gradle.plugins.dagger.properties
+++ b/dagger-plugin/src/main/resources/META-INF/gradle-plugins/com.ewerk.gradle.plugins.dagger.properties
@@ -1,0 +1,1 @@
+implementation-class=com.ewerk.gradle.plugins.DaggerPlugin

--- a/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/DaggerPluginTest.groovy
+++ b/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/DaggerPluginTest.groovy
@@ -8,6 +8,7 @@ import org.gradle.testfixtures.ProjectBuilder;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test
 
+import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.hasItem
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -57,8 +58,25 @@ public class DaggerPluginTest {
   @Test
   public void testPluginEvaluatesCompileOptions() {
     project.evaluate()
-    def args = project.tasks.compileJava.options.compilerArgs
-    assertThat(args, hasItems('-s', new File(project.projectDir, DaggerPluginExtension.DEFAULT_DAGGER_SOURCES_DIR).path))
+    def args = project.tasks.compileDagger.options.compilerArgs as List
+    assertThat(args, hasItems('-proc:only', '-s', '-processor', DaggerPluginExtension.PROCESSOR,
+        new File(project.projectDir, DaggerPluginExtension.DEFAULT_DAGGER_SOURCES_DIR).path))
   }
+
+  @Test
+  public void testDefaultGeneratedSourcesDirIsSet() {
+    assertThat(project.extensions.dagger.daggerSourcesDir as String, equalTo(DaggerPluginExtension.DEFAULT_DAGGER_SOURCES_DIR))
+  }
+
+  @Test
+  public void testDefaultLibraryIsSet() {
+    assertThat(project.extensions.dagger.library as String, equalTo(DaggerPluginExtension.DEFAULT_LIBRARY))
+  }
+
+  @Test
+  public void testDefaultProcessorIsSet() {
+    assertThat(project.extensions.dagger.processorLibrary as String, equalTo(DaggerPluginExtension.DEFAULT_PROCESSOR_LIBRARY))
+  }
+
 
 }

--- a/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/DaggerPluginTest.groovy
+++ b/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/DaggerPluginTest.groovy
@@ -1,0 +1,64 @@
+package com.ewerk.gradle.plugins;
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.WarPlugin;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test
+
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author griffio
+ */
+public class DaggerPluginTest {
+
+  private Project project
+
+  @BeforeMethod
+  public void setup() {
+    project = ProjectBuilder.builder().build()
+    project.plugins.apply(DaggerPlugin.class)
+    project.plugins.apply(WarPlugin.class)
+  }
+
+  @Test
+  public void testBasePlugin() {
+    assertThat(project.plugins.hasPlugin(BasePlugin.class), is(true))
+  }
+
+  @Test
+  public void testPluginAppliesItself() {
+    assertThat(project.plugins.hasPlugin(DaggerPlugin.class), is(true))
+  }
+
+  @Test
+  public void testReApplyDoesNotFail() {
+    project.plugins.apply(DaggerPlugin.class)
+  }
+
+  @Test
+  public void testPluginAppliesJavaPlugin() {
+    assertThat(project.plugins.hasPlugin(JavaPlugin.class), is(true))
+  }
+
+  @Test
+  public void testPluginEvaluatesDependencies() {
+    project.evaluate()
+    def lib = project.configurations.compile.dependencies.collect { "$it.group:$it.name:$it.version" as String }.toSet()
+    assertThat(lib, hasItem(project.extensions.dagger.library))
+  }
+
+  @Test
+  public void testPluginEvaluatesCompileOptions() {
+    project.evaluate()
+    def args = project.tasks.compileJava.options.compilerArgs
+    assertThat(args, hasItems('-s', new File(project.projectDir, DaggerPluginExtension.DEFAULT_DAGGER_SOURCES_DIR).path))
+  }
+
+}

--- a/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/tasks/DaggerTaskTest.groovy
+++ b/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/tasks/DaggerTaskTest.groovy
@@ -1,0 +1,48 @@
+package com.ewerk.gradle.plugins.tasks
+
+import com.ewerk.gradle.plugins.DaggerPlugin
+import com.ewerk.gradle.tasks.CleanDaggerSourcesDir
+import com.ewerk.gradle.tasks.InitDaggerSourcesDir
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+import static org.hamcrest.CoreMatchers.equalTo
+import static org.hamcrest.CoreMatchers.notNullValue
+import static org.hamcrest.MatcherAssert.assertThat
+
+/**
+ * @griffio
+ */
+class DaggerTaskTest {
+
+  private Project project;
+
+  private InitDaggerSourcesDir initTask;
+  private CleanDaggerSourcesDir cleanTask;
+
+  @BeforeMethod
+  public void setup() {
+    project = ProjectBuilder.builder().build()
+    project.plugins.apply(DaggerPlugin.class)
+    project.evaluate()
+    initTask = project.tasks.initDaggerSourcesDir as InitDaggerSourcesDir
+    cleanTask = project.tasks.cleanDaggerSourcesDir as CleanDaggerSourcesDir
+  }
+
+  @Test
+  void initSourceFolders() {
+    initTask.createSourceFolders()
+    assertThat(project.sourceSets.dagger, notNullValue())
+    File javaDir = project.sourceSets.dagger.java.srcDirs.first() as File
+    assertThat(javaDir.name, equalTo("java"))
+  }
+
+  @Test
+  public void taskGroup() {
+    assertThat(cleanTask.group, equalTo(DaggerPlugin.TASK_GROUP));
+    assertThat(initTask.group, equalTo(DaggerPlugin.TASK_GROUP));
+  }
+
+}

--- a/sample-application/build.gradle
+++ b/sample-application/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+
+  repositories {
+    mavenLocal()
+  }
+
+  dependencies {
+    classpath group: 'com.ewerk.gradle.plugins', name: 'dagger-plugin', version: '1.0.0-SNAPSHOT'
+  }
+
+}
+
 plugins {
   id "java"
   id "war"
@@ -5,6 +17,8 @@ plugins {
   id "com.ewerk.gradle.plugins.integration-test" version "1.0.7"
   id "com.ewerk.gradle.plugins.querydsl" version "1.0.4"
 }
+
+apply plugin: 'com.ewerk.gradle.plugins.dagger'
 
 repositories {
   mavenLocal()
@@ -32,10 +46,14 @@ querydsl {
   querydslDefault = true
 }
 
+
+
 test {
   useTestNG()
+  maxHeapSize = "128m"
 }
 
 integrationTest {
   useTestNG()
+  maxHeapSize = "128m"
 }

--- a/sample-application/src/main/java/com/ewerk/gradle/plugins/sample/AnyComponent.java
+++ b/sample-application/src/main/java/com/ewerk/gradle/plugins/sample/AnyComponent.java
@@ -1,0 +1,8 @@
+package com.ewerk.gradle.plugins.sample;
+
+import dagger.Component;
+
+@Component(modules = AnyModule.class)
+public interface AnyComponent {
+   AnyThing thing();
+}

--- a/sample-application/src/main/java/com/ewerk/gradle/plugins/sample/AnyModule.java
+++ b/sample-application/src/main/java/com/ewerk/gradle/plugins/sample/AnyModule.java
@@ -1,0 +1,12 @@
+package com.ewerk.gradle.plugins.sample;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public class AnyModule {
+  @Provides
+  AnyThing provideAnyThing() {
+    return new AnyThing();
+  }
+}

--- a/sample-application/src/main/java/com/ewerk/gradle/plugins/sample/AnyThing.java
+++ b/sample-application/src/main/java/com/ewerk/gradle/plugins/sample/AnyThing.java
@@ -1,0 +1,11 @@
+package com.ewerk.gradle.plugins.sample;
+
+public class AnyThing {
+
+  public AnyThing() {
+  }
+
+  public boolean isAnyThing() {
+    return true;
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = "gradle-plugins"
-include "integration-test-plugin", "auto-value-plugin", "querydsl-plugin", "sample-application"
+include  "auto-valu e-plugin", "dagger-plugin", "integration-test-plugin", "querydsl-plugin", "sample-application"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = "gradle-plugins"
-include  "auto-valu e-plugin", "dagger-plugin", "integration-test-plugin", "querydsl-plugin", "sample-application"
+include  "auto-value-plugin", "dagger-plugin", "integration-test-plugin", "querydsl-plugin", "sample-application"


### PR DESCRIPTION
gradle-plugins/sample-application/build.gradle

The sample build file is using the local snapshot release from so that it runs for testing.

It would be changed to: id "com.ewerk.gradle.plugins.dagger" version "1.0.0" before going to release branch.

---

The "sample-application" project has dependencies on all plugins and the entire build fails.

Gradle cannot exclude sub-projects at the command line.

One way to solve it is to add another "settings.gradle" e.g "plugin-settings.gradle" that doesn't include the "sample-applications" project and then invoke the build. 
~~~
./gradlew --settings-file plugin-settings.gradle install
~~~

The above will install the snapshot plugin dependencies that are updated.

then run tests as normal.

~~~
./gradlew test
~~~
