### PR TITLE
support for custom processor

### DIFF
--- a/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/QuerydslPluginExtension.groovy
+++ b/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/QuerydslPluginExtension.groovy
@@ -33,6 +33,8 @@ class QuerydslPluginExtension {
   boolean springDataMongo = false;
   boolean querydslDefault = false;
 
+  String customProcessor = null;
+
   String processors() {
 
     List processors = []
@@ -63,6 +65,10 @@ class QuerydslPluginExtension {
 
     if (springDataMongo) {
       processors << SPRING_DATA_MONGO_PROC
+    }
+
+    if (customProcessor) {
+      processors << customProcessor
     }
 
     return processors.join(",")

--- a/querydsl-plugin/src/test/groovy/com/ewerk/gradle/plugins/QuerydslPluginExtensionTest.groovy
+++ b/querydsl-plugin/src/test/groovy/com/ewerk/gradle/plugins/QuerydslPluginExtensionTest.groovy
@@ -19,6 +19,7 @@ package com.ewerk.gradle.plugins
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
+import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.MatcherAssert.assertThat
 
@@ -46,5 +47,12 @@ class QuerydslPluginExtensionTest {
     def defaultLibrary = QuerydslPluginExtension.DEFAULT_LIBRARY
     assertThat(extension.library,
         equalTo(defaultLibrary));
+  }
+
+  @Test
+  public void testCustomProcessorIsContained() {
+    String customProcessorName = "customProcessor";
+    extension.customProcessor = customProcessorName;
+    assertThat(extension.processors(), containsString(customProcessorName));
   }
 }


### PR DESCRIPTION
Just updated the querydsl package to version 4.0.1 which has now new package names for the apt processors. Wouldn't it be good to support custom processors in addition to the existing ones?

Feel free to choose a better name for the parameter or support a list parameter with multiple custom processors.