### PR TITLE
Dagger plugin with Android sdk support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ script: ./gradlew build
 branches:
   only:
     - master
-    - android-sdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ script: ./gradlew build
 branches:
   only:
     - master
+    - android-sdk

--- a/dagger-plugin/build.gradle
+++ b/dagger-plugin/build.gradle
@@ -18,9 +18,16 @@ pluginBundle {
   }
 }
 
+repositories {
+  mavenCentral()
+}
+
 dependencies {
   compile gradleApi()
   compile localGroovy()
+  testCompile 'com.android.tools.build:gradle:1.2.3'
+  testCompile 'com.jakewharton.sdkmanager:gradle-plugin:0.12.+'
+
 }
 
 test {

--- a/dagger-plugin/change_log.md
+++ b/dagger-plugin/change_log.md
@@ -4,4 +4,4 @@
 * Initial release
 
 ## 1.0.1
-* current snapshot
+* Add basic Android project support for Android Studio projects

--- a/dagger-plugin/readme.md
+++ b/dagger-plugin/readme.md
@@ -6,6 +6,8 @@
 
 This plugin uses the [Dagger2](http://google.github.io/dagger/) compiler to process annotations that are compatible with JSR-330.
 
+Gradle Java/Android plugin support (imported into Intellij/Android Studio).
+
 [This plugins change log](change_log.md).
 
 #### Configuration
@@ -14,7 +16,9 @@ This plugin uses the [Dagger2](http://google.github.io/dagger/) compiler to proc
 
 The destination directory for the generated Dagger java source.
 
-Defaults to 'src/dagger/java'.
+Defaults to 'src/dagger/java' for Java Plugin projects.
+
+Android projects always use '${buildDir}/generated/source/dagger/<variant>' to maintain Android convention.
 
 ##### library
 
@@ -35,7 +39,7 @@ __Use via Gradle plugin portal__
 
 ```groovy
 plugins {
-  id "com.ewerk.gradle.plugins.dagger" version "1.0.0"
+  id "com.ewerk.gradle.plugins.dagger" version "1.0.1"
 }
 ```
 
@@ -48,7 +52,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.ewerk.gradle.plugins:dagger-plugin:1.0.0"
+    classpath "gradle.plugin.com.ewerk.gradle.plugins:dagger-plugin:1.0.1"
   }
 }
 

--- a/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPlugin.groovy
+++ b/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPlugin.groovy
@@ -18,11 +18,12 @@ import org.gradle.api.tasks.Delete
  * Dagger2 (http://google.github.io/dagger/) is a library with a processor dependency (com.google.dagger:dagger-compiler)
  * and compile transitive dependency (com.google.dagger:dagger) that is required for the generated code.
  *
- * apply configuration to JavaPlugin project
+ * Apply configuration to JavaPlugin project.
+ *   A separate DaggerCompile task is executed with the annotation processor
  *
- * apply configuration to Android project
- *  The source is ${project.buildDir}/generated/source/dagger/<variant>
- *
+ * Apply configuration to Android project.
+ *   The source is ${project.buildDir}/generated/source/dagger/<variant>
+ *   The variant.javaCompile compile task is executed with the annotation processor
  */
 public class DaggerPlugin implements Plugin<Project> {
 

--- a/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/DaggerAndroidPluginTest.groovy
+++ b/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/DaggerAndroidPluginTest.groovy
@@ -8,17 +8,19 @@ import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
 import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.hasItems
 import static org.hamcrest.CoreMatchers.is
 import static org.hamcrest.MatcherAssert.assertThat
 
 /**
  * @author griffio
  *
- *
+ * android-sdk-manager will download the specified sdk
  */
 public class DaggerAndroidPluginTest {
 
   private Project project
+  private File generatedDir
 
   @BeforeMethod
   public void androidProject() {
@@ -27,7 +29,6 @@ public class DaggerAndroidPluginTest {
     project.plugins.apply('android-sdk-manager')
     project.plugins.apply('android')
     project.plugins.apply(DaggerPlugin.class)
-    //BasePlugin,init SdkHandler
     project.android {
       compileSdkVersion "android-21"
       buildToolsVersion "21.1.2"
@@ -42,6 +43,8 @@ public class DaggerAndroidPluginTest {
     project.repositories {
       mavenCentral()
     }
+
+    generatedDir = new File(project.projectDir, "/build/generated/source/dagger")
 
   }
 
@@ -61,9 +64,13 @@ public class DaggerAndroidPluginTest {
   @Test
   public void testVariant() {
     project.evaluate()
-    project.android.applicationVariants.all { v ->
-      println(v.dirName)
+    project.android.applicationVariants.all { variant ->
+      def args = variant.javaCompile.options.compilerArgs as List
+      assertThat(args, hasItems('-s', '-processor', DaggerPluginExtension.PROCESSOR,
+          new File(generatedDir, variant.dirName as String).path))
     }
+
   }
+
 
 }

--- a/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/DaggerAndroidPluginTest.groovy
+++ b/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/DaggerAndroidPluginTest.groovy
@@ -1,0 +1,69 @@
+package com.ewerk.gradle.plugins
+
+import com.android.build.gradle.AppPlugin
+import com.android.build.gradle.LibraryPlugin
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.is
+import static org.hamcrest.MatcherAssert.assertThat
+
+/**
+ * @author griffio
+ *
+ *
+ */
+public class DaggerAndroidPluginTest {
+
+  private Project project
+
+  @BeforeMethod
+  public void androidProject() {
+    Project root = ProjectBuilder.builder().build();
+    project = ProjectBuilder.builder().withParent(root).build()
+    project.plugins.apply('android-sdk-manager')
+    project.plugins.apply('android')
+    project.plugins.apply(DaggerPlugin.class)
+    //BasePlugin,init SdkHandler
+    project.android {
+      compileSdkVersion "android-21"
+      buildToolsVersion "21.1.2"
+      defaultConfig {
+        minSdkVersion 15
+        targetSdkVersion 21
+        versionCode 1
+        versionName "1.0"
+      }
+    }
+
+    project.repositories {
+      mavenCentral()
+    }
+
+  }
+
+  @Test
+  public void testPlugins() {
+    assertThat(project.plugins.hasPlugin(AppPlugin) || project.plugins.hasPlugin(LibraryPlugin), is(true))
+  }
+
+  @Test
+  public void testPluginDependencies() {
+    def lib = project.configurations.compile.dependencies.collect {
+      "$it.group:$it.name:$it.version" as String
+    }.toSet()
+    assertThat(lib, hasItem(project.extensions.dagger.library))
+  }
+
+  @Test
+  public void testVariant() {
+    project.evaluate()
+    project.android.applicationVariants.all { v ->
+      println(v.dirName)
+    }
+  }
+
+}

--- a/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/DaggerJavaPluginTest.groovy
+++ b/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/DaggerJavaPluginTest.groovy
@@ -14,7 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat
 /**
  * @author griffio
  */
-public class DaggerPluginTest {
+public class DaggerJavaPluginTest {
 
   private Project project
 


### PR DESCRIPTION
The existing Dagger Plugin has been updated to add support for Android projects(e.g Android Studio).

The main difference is the generated source directory is based on Android convention and cannot be changed. The annotation processor is configured on the variant.javacompile task to provide basic support. 

It has been tested on builds https://travis-ci.org/griffio/gradle-plugins since the unit test require a android-sdk to be present in the environment.

The Android project [Android-CleanArchitecture,](https://github.com/android10/Android-CleanArchitecture), as an example, can be changed to use the plugin.