### PR TITLE
issues#27

### DIFF
--- a/plugins/auto-value-plugin/readme.md
+++ b/plugins/auto-value-plugin/readme.md
@@ -11,13 +11,31 @@ minor changes. This is documented in the [change log](change_log.md).
 Version 1.0.3 of the plugin was accidentally build and published with JDK-8 which breaks 
 compatibility to JDK-7. This was fixed in version 1.0.4.
 
+#### Configuration
+
+##### autoValueSourcesDir
+
+The destination directory for the generated java sources.
+
+Defaults to 'src/auto-value/java' for Java Plugin projects.
+
+The autoValueSourcesDir is deleted when executing the clean task; for this reason, a BuildException will be thrown if
+autoValueSourcesDir is located in your main java sources.
+
+##### library
+
+The dependency artifact for the compile/runtime usage of Autovalue.
+This is added to the compile configuration for the project.
+
+Defaults to 'com.google.auto.value:auto-value:1.0'.
+
 #### Examples
 
 __Use via Gradle plugin portal__
 
 ```groovy
 plugins {
-  id "com.ewerk.gradle.plugins.auto-value" version "1.0.1"
+  id "com.ewerk.gradle.plugins.auto-value" version "1.0.5"
 }
 ```
 
@@ -30,7 +48,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.ewerk.gradle.plugins:auto-value-plugin:1.0.3"
+    classpath "com.ewerk.gradle.plugins:auto-value-plugin:1.0.5"
   }
 }
 
@@ -38,7 +56,7 @@ apply plugin: "com.ewerk.gradle.plugins.auto-value"
 
 // the following closure demonstrates the extension defaults and is not necessary
 autoValue {
-  library = "com.google.auto.value:auto-value:1.0"
+  library = "com.google.auto.value:auto-value:1.1"
   autoValueSourcesDir = "src/auto-value/java"
 }
 ```

--- a/plugins/auto-value-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/InitAutoValueSourcesDir.groovy
+++ b/plugins/auto-value-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/InitAutoValueSourcesDir.groovy
@@ -2,6 +2,7 @@ package com.ewerk.gradle.plugins.tasks
 
 import com.ewerk.gradle.plugins.AutoValuePlugin
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.TaskAction
@@ -26,6 +27,17 @@ class InitAutoValueSourcesDir extends DefaultTask {
   @SuppressWarnings("GroovyUnusedDeclaration")
   @TaskAction
   def createSourceFolders() {
+
+    def autoValueSourcesDir = project.file(project.autoValue.autoValueSourcesDir)
+
+    LOG.info("Create source set ${autoValueSourcesDir}.");
+
+    project.sourceSets.main.java.srcDirs.each { d ->
+      if (d.absolutePath.equals(autoValueSourcesDir.absolutePath)) {
+        throw new GradleException("The configured autoValueSourcesDir must specify a separate location to existing source code.")
+      }
+    }
+
     project.file(project.autoValue.autoValueSourcesDir).mkdirs()
   }
 }

--- a/plugins/auto-value-plugin/src/test/groovy/com/ewerk/gradle/plugins/tasks/InitAutoValueSourcesDirTest.groovy
+++ b/plugins/auto-value-plugin/src/test/groovy/com/ewerk/gradle/plugins/tasks/InitAutoValueSourcesDirTest.groovy
@@ -1,6 +1,7 @@
 package com.ewerk.gradle.plugins.tasks
 
 import com.ewerk.gradle.plugins.AutoValuePlugin
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.testng.annotations.BeforeMethod
@@ -29,8 +30,15 @@ class InitAutoValueSourcesDirTest {
     createTask = project.tasks.initAutoValueSourcesDir as InitAutoValueSourcesDir
   }
 
-  @Test
+  @Test(expectedExceptions = GradleException.class, expectedExceptionsMessageRegExp="The configured autoValueSourcesDir.*")
   void testCreateSourceFolders() {
+    project.autoValue.autoValueSourcesDir = "src/main/java"
+    createTask.createSourceFolders()
+  }
+
+  @Test
+  void testCreateSourceFoldersBuildFail() {
+
     createTask.createSourceFolders()
     assertThat(project.sourceSets.autoValue, notNullValue())
 


### PR DESCRIPTION
Raise a buildException to prevent the autoValueSourcesDir being located in src main java.
The clean task would be able to delete the main java sources.