### PR TITLE
issue#32

### DIFF
--- a/plugins/dagger-plugin/readme.md
+++ b/plugins/dagger-plugin/readme.md
@@ -18,6 +18,9 @@ The destination directory for the generated Dagger java source.
 
 Defaults to 'src/dagger/java' for Java Plugin projects.
 
+The daggerSourcesDir is deleted when executing the clean task; for this reason, a BuildException will be thrown if
+daggerSourcesDir is located as your main java sources.
+
 Android projects always use '${buildDir}/generated/source/dagger/<variant>' to maintain Android convention.
 
 ##### library

--- a/plugins/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPlugin.groovy
+++ b/plugins/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPlugin.groovy
@@ -147,7 +147,7 @@ public class DaggerPlugin implements Plugin<Project> {
     return project.plugins.hasPlugin('com.android.application') || project.plugins.hasPlugin('com.android.library')
   }
 
-  static def projectAndroidVariants(project) {
+  static def projectAndroidVariants(Project project) {
     if (project.android.hasProperty('applicationVariants')) {
       return project.android.applicationVariants
     } else if (project.android.hasProperty('libraryVariants')) {
@@ -157,4 +157,13 @@ public class DaggerPlugin implements Plugin<Project> {
     }
   }
 
+  static def verifyNotWithinMainBuildSrc(Project project) {
+    def daggerSourcesDir = project.file(project.dagger.daggerSourcesDir) as File
+    project.sourceSets.main.java.srcDirs.each { d ->
+      if (d.absolutePath.equals(daggerSourcesDir.absolutePath)) {
+        throw new GradleException("The configured daggerSourcesDir must specify a separate location to existing source code.")
+      }
+    }
+    return daggerSourcesDir
+  }
 }

--- a/plugins/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/CleanDaggerSourcesDir.groovy
+++ b/plugins/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/CleanDaggerSourcesDir.groovy
@@ -22,10 +22,9 @@ class CleanDaggerSourcesDir extends DefaultTask {
   @TaskAction
   def cleanSourceFolders() {
     LOG.info("clean Source")
-    project.sourceSets.dagger.java.srcDirs.each { dir ->
-      if (dir.exists()) {
-        dir.deleteDir()
-      }
+    def daggerSourcesDir = DaggerPlugin.verifyNotWithinMainBuildSrc(project)
+    if (daggerSourcesDir.exists()) {
+      daggerSourcesDir.deleteDir()
     }
   }
 }

--- a/plugins/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/InitDaggerSourcesDir.groovy
+++ b/plugins/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/InitDaggerSourcesDir.groovy
@@ -22,6 +22,7 @@ class InitDaggerSourcesDir extends DefaultTask {
   @TaskAction
   def createSourceFolders() {
     LOG.info("create source")
-    project.file(project.dagger.daggerSourcesDir).mkdirs()
+    def daggerSourcesDir = DaggerPlugin.verifyNotWithinMainBuildSrc(project)
+    daggerSourcesDir.mkdirs()
   }
 }

--- a/plugins/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/tasks/DaggerTaskTest.groovy
+++ b/plugins/dagger-plugin/src/test/groovy/com/ewerk/gradle/plugins/tasks/DaggerTaskTest.groovy
@@ -1,6 +1,7 @@
 package com.ewerk.gradle.plugins.tasks
 
 import com.ewerk.gradle.plugins.DaggerPlugin
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.testng.annotations.BeforeMethod
@@ -27,6 +28,18 @@ class DaggerTaskTest {
     project.evaluate()
     initTask = project.tasks.initDaggerSourcesDir as InitDaggerSourcesDir
     cleanTask = project.tasks.cleanDaggerSourcesDir as CleanDaggerSourcesDir
+  }
+
+  @Test(expectedExceptions = GradleException.class, expectedExceptionsMessageRegExp="The configured daggerSourcesDir.*")
+  void testCreateSourceFoldersException() {
+    project.dagger.daggerSourcesDir = "src/main/java"
+    initTask.createSourceFolders()
+  }
+
+  @Test(expectedExceptions = GradleException.class, expectedExceptionsMessageRegExp="The configured daggerSourcesDir.*")
+  void testCleanSourceFoldersException() {
+    project.dagger.daggerSourcesDir = "src/main/java"
+    cleanTask.cleanSourceFolders()
   }
 
   @Test


### PR DESCRIPTION
Add check of daggerSourcesDir to avoid deleting main java sourceSet.

Snapshot version will need to be updated after integration.
