### PR TITLE
closes issue #51

### DIFF
--- a/querydsl-plugin/change_log.md
+++ b/querydsl-plugin/change_log.md
@@ -22,3 +22,6 @@
 ## 1.0.6
 * Querydsl 4 library dependency is now required for this plugin.
 * Querydsl 4 is required for SpringData "Hopper" JPA generation.
+
+## 1.0.7
+* Bugfix (issue #51) for compileQuerydsl task, Java compiler setting of destinationDir, must evaluate user's querydslSourcesDir preference.

--- a/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/QuerydslCompile.groovy
+++ b/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/QuerydslCompile.groovy
@@ -2,7 +2,6 @@ package com.ewerk.gradle.plugins.tasks
 
 import org.gradle.api.plugins.WarPlugin
 import org.gradle.api.tasks.compile.JavaCompile
-
 /**
  * Compiles the meta model using querydsl annotation processors supplied by the querydsl extension configuration
  * @author holgerstolzenberg , griffio
@@ -23,9 +22,10 @@ class QuerydslCompile extends JavaCompile {
       }
     }
 
-    setClasspath(project.configurations.querydsl)
-
-    File file = project.file(project.querydsl.querydslSourcesDir)
-    setDestinationDir(file)
+    project.afterEvaluate {
+      setClasspath(project.configurations.querydsl)
+      File file = project.file(project.querydsl.querydslSourcesDir)
+      setDestinationDir(file)
+    }
   }
 }

--- a/querydsl-plugin/src/test/groovy/com/ewerk/gradle/plugins/QuerydslPluginTest.groovy
+++ b/querydsl-plugin/src/test/groovy/com/ewerk/gradle/plugins/QuerydslPluginTest.groovy
@@ -84,4 +84,12 @@ class QuerydslPluginTest {
     assertThat(id, equalTo(QuerydslPluginExtension.DEFAULT_LIBRARY));
     assertThat(project.tasks.compileQuerydsl, notNullValue())
   }
+
+  @Test
+  public void testSourcesDirAfterEvaluate() {
+    project.extensions.querydsl.querydslSourcesDir = "/java/other/src"
+    project.evaluate()
+    File sourcesDir = project.file(project.querydsl.querydslSourcesDir) as File
+    assertThat(sourcesDir, equalTo(project.tasks.compileQuerydsl.destinationDir as File))
+  }
 }


### PR DESCRIPTION
Moves the setDestinationDir(file) to project.afterEvaluate so that javac will use the gradle dsl user value.