### PR TITLE
Querydsl update default library (4.1.3) to current default Spring Data version

### DIFF
--- a/querydsl-plugin/change_log.md
+++ b/querydsl-plugin/change_log.md
@@ -25,3 +25,6 @@
 
 ## 1.0.7
 * Bugfix (issue #51) for compileQuerydsl task, Java compiler setting of destinationDir, must evaluate user's querydslSourcesDir preference.
+
+## 1.0.8
+* Querydsl 4 library dependency updated to (4.1.3) matching Spring Data version

--- a/querydsl-plugin/readme.md
+++ b/querydsl-plugin/readme.md
@@ -16,7 +16,7 @@ Please have a look at the plugins [change log](change_log.md).
 ##### library
 The artifact coordinates of the Querydsl annotation processor library.
 
-Defaults to `com.querydsl:querydsl-apt:4.0.9`.
+Defaults to `com.querydsl:querydsl-apt:4.1.3`.
 
 Note: this can only be a version supported by the current [Spring Data](http://projects.spring.io/spring-data/) project.
 
@@ -89,7 +89,7 @@ __Mongo example__
 
 ```groovy
 plugins {
-  id "com.ewerk.gradle.plugins.querydsl" version "1.0.6"
+  id "com.ewerk.gradle.plugins.querydsl" version "1.0.8"
 }
 
 repositories {
@@ -102,7 +102,7 @@ dependencies {
   compile "org.springframework.data:spring-data-mongodb:1.9.1.RELEASE"
 
   // use Querydsl against MongoDB
-  compile "com.querydsl.apt:querydsl-mongodb:4.0.9"
+  compile "com.querydsl.apt:querydsl-mongodb:4.1.3"
   […]
 }
 

--- a/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/QuerydslPluginExtension.groovy
+++ b/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/QuerydslPluginExtension.groovy
@@ -19,7 +19,7 @@ class QuerydslPluginExtension {
   static String SPRING_DATA_MONGO_PROC = "org.springframework.data.mongodb.repository.support.MongoAnnotationProcessor"
 
   static final String NAME = "querydsl"
-  static final String DEFAULT_QUERYDSL_SOURCES_DIR = new File("src/querydsl/java")
+  static final String DEFAULT_QUERYDSL_SOURCES_DIR = "src/querydsl/java"
   static final String DEFAULT_LIBRARY = "com.querydsl:querydsl-apt:4.0.9"
 
   String querydslSourcesDir = DEFAULT_QUERYDSL_SOURCES_DIR

--- a/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/QuerydslPluginExtension.groovy
+++ b/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/QuerydslPluginExtension.groovy
@@ -20,7 +20,7 @@ class QuerydslPluginExtension {
 
   static final String NAME = "querydsl"
   static final String DEFAULT_QUERYDSL_SOURCES_DIR = "src/querydsl/java"
-  static final String DEFAULT_LIBRARY = "com.querydsl:querydsl-apt:4.0.9"
+  static final String DEFAULT_LIBRARY = "com.querydsl:querydsl-apt:4.1.3"
 
   String querydslSourcesDir = DEFAULT_QUERYDSL_SOURCES_DIR
   String library = DEFAULT_LIBRARY


### PR DESCRIPTION
For 1.0.8

**Todo**
Update Dagger2 -> 2.6.1
Update samples after release