### PR TITLE
Dagger updated to 2.7 and fixed change_log to 1.0.4-SNAPSHOT

### DIFF
--- a/dagger-plugin/change_log.md
+++ b/dagger-plugin/change_log.md
@@ -12,6 +12,6 @@
 ## 1.0.3
 * Make sure clean task does not delete any main source set
 
-## 1.0.4
-* Updated Dagger2 default library to 2.6.1
+## 1.0.4-SNAPSHOT
+* Updated Dagger2 default library to 2.7
 * Check releases for changes - https://github.com/google/dagger/releases

--- a/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPluginExtension.groovy
+++ b/dagger-plugin/src/main/groovy/com/ewerk/gradle/plugins/DaggerPluginExtension.groovy
@@ -9,8 +9,8 @@ public class DaggerPluginExtension {
 
   static final String NAME = "dagger"
   static final String DEFAULT_DAGGER_SOURCES_DIR = "src/dagger/java"
-  static final String DEFAULT_PROCESSOR_LIBRARY = "com.google.dagger:dagger-compiler:2.6.1"
-  static final String DEFAULT_LIBRARY = "com.google.dagger:dagger:2.6.1"
+  static final String DEFAULT_PROCESSOR_LIBRARY = "com.google.dagger:dagger-compiler:2.7"
+  static final String DEFAULT_LIBRARY = "com.google.dagger:dagger:2.7"
   static final String PROCESSOR = "dagger.internal.codegen.ComponentProcessor"
 
   String daggerSourcesDir = DEFAULT_DAGGER_SOURCES_DIR


### PR DESCRIPTION
I think updating plugin default libraries can be done when **semver** minor updates are made rather than patch releases.
