### PR TITLE
WIP: Groovy support

### DIFF
--- a/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/QuerydslCompileGroovy.groovy
+++ b/querydsl-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/QuerydslCompileGroovy.groovy
@@ -1,0 +1,32 @@
+package com.ewerk.gradle.plugins.tasks
+
+import org.gradle.api.plugins.WarPlugin
+import org.gradle.api.tasks.compile.GroovyCompile
+
+/**
+ * Compiles the meta model using querydsl annotation processors supplied by the querydsl extension configuration
+ * @author holgerstolzenberg , griffio
+ * @since 1.0.3
+ */
+class QuerydslCompileGroovy extends GroovyCompile {
+
+  QuerydslCompileGroovy() {
+    setSource(project.sourceSets.main.groovy)
+
+    if (project.plugins.hasPlugin(WarPlugin.class)) {
+      project.configurations {
+        querydsl.extendsFrom compile, providedRuntime, providedCompile
+      }
+    } else {
+      project.configurations {
+        querydsl.extendsFrom compile
+      }
+    }
+
+    project.afterEvaluate {
+      setClasspath(project.configurations.querydsl)
+      File file = project.file(project.querydsl.querydslSourcesDir)
+      setDestinationDir(file)
+    }
+  }
+}


### PR DESCRIPTION
Apologies for the delay. I haven't used querydsl professionally for a long while. Yet, promise is a promise, so here it is: a quick initial POC to address #73 
Will rewrite properly after discussion.

Groovy/java project to test: https://github.com/tadaskay/querydsl-groovy-gradle-poc

However, I was only able to make it work by removing `"-proc:only"` from `compilerArgs`. With this setting, compilation fails: 
```
> Task :compileQuerydsl
Note: Running JPAAnnotationProcessor
Note: Serializing Entity types
Note: Generating com.example.demo.todo.QTodo for [com.example.demo.todo.Todo]
Note: Running JPAAnnotationProcessor
Note: Running JPAAnnotationProcessor
startup failed:
C:\dev\prj\querydsl-groovy\src\main\groovy\com\example\demo\DemoApplication.groovy: 3: unable to resolve class com.example.demo.todo.TodoService
 @ line 3, column 1.
   import com.example.demo.todo.TodoService
   ^

1 error
```
Why was it there in the first place?

As I have mentioned in #73, I had a working Groovy/java setup. I took a slightly different approach to avoid compiling extra classes (non-querydsl): added excludes in the querydsl compile task, e.g.
```groovy
    exclude(
        '**/*Delegate*.*',
        '**/*Service*.*',
        '**/*Mapper*.*',
        '**/*Repository*.*',
     ...
```
But it's really cumbersome to write and maintain. Haven't found an elegant solution to this though.
Or maybe I'm just missing something.

Your thoughts are much appreciated @holgerstolzenberg 