### PR TITLE
issue#100 IntegrationTest plugin deprecated getTestClassesDir

### DIFF
--- a/integration-test-plugin/src/main/groovy/com/ewerk/gradle/plugins/IntegrationTestPlugin.groovy
+++ b/integration-test-plugin/src/main/groovy/com/ewerk/gradle/plugins/IntegrationTestPlugin.groovy
@@ -73,7 +73,7 @@ class IntegrationTestPlugin implements Plugin<Project> {
 
     project.task("integrationTest", type: Test, description: "Runs the integration tests.",
         group: GROUP) {
-      testClassesDir = project.sourceSets.integration.output.classesDir
+      testClassesDirs = project.sourceSets.integration.output
       classpath = project.sourceSets.integration.runtimeClasspath
     }
 

--- a/integration-test-plugin/src/test/groovy/com/ewerk/gradle/plugins/IntegrationTestPluginTest.groovy
+++ b/integration-test-plugin/src/test/groovy/com/ewerk/gradle/plugins/IntegrationTestPluginTest.groovy
@@ -2,6 +2,7 @@ package com.ewerk.gradle.plugins
 
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSet
@@ -80,5 +81,12 @@ class IntegrationTestPluginTest {
     SourceSet integration = project.sourceSets.integration
     SourceDirectorySet resources = integration.resources
     assertThat(resources, notNullValue())
+  }
+
+  @Test
+  void testIntegrationTestClassesDirDeprecated() {
+    org.gradle.api.tasks.testing.Test integrationTest = project.tasks.integrationTest as org.gradle.api.tasks.testing.Test
+    FileCollection tree = integrationTest.getTestClassesDirs()
+    assertThat(tree.getFiles().first(), equalTo(integrationTest.getTestClassesDir()))
   }
 }


### PR DESCRIPTION
getTestClassesDir is deprecated in gradle 4.x
getTestClassesDirs is used instead to store the sourceset tree

Note: Once applied will break compatibility with gradle 3.x

see http://www.thinkcode.se/blog/2017/08/14/gradle-settestclassesdirfile-method-has-been-deprecated