### PR TITLE
Make creating the sourceSet optional.

### DIFF
--- a/jaxb2-plugin/src/main/groovy/com/ewerk/gradle/plugins/Jaxb2Plugin.groovy
+++ b/jaxb2-plugin/src/main/groovy/com/ewerk/gradle/plugins/Jaxb2Plugin.groovy
@@ -99,17 +99,19 @@ class Jaxb2Plugin implements Plugin<Project> {
     Set<XjcTaskConfig> xjcConfigs = project.extensions.jaxb2.xjc
 
     for (XjcTaskConfig theConfig : xjcConfigs) {
-      File sourcesDir = project.file(theConfig.generatedSourcesDir)
-      LOG.info("Create source set 'jaxb2': {}", sourcesDir.absolutePath)
+      if (theConfig.createSourceSet) {
+        File sourcesDir = project.file(theConfig.generatedSourcesDir)
+        LOG.info("Create source set 'jaxb2': {}", sourcesDir.absolutePath)
 
-      project.sourceSets {
-        jaxb2 {
-          java.srcDirs += [sourcesDir]
+        project.sourceSets {
+          jaxb2 {
+            java.srcDirs += [sourcesDir]
+          }
         }
-      }
 
-      project.compileJava {
-        source += project.files(sourcesDir)
+        project.compileJava {
+          source += project.files(sourcesDir)
+        }
       }
     }
   }

--- a/jaxb2-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/InitJaxb2SourcesDir.groovy
+++ b/jaxb2-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/InitJaxb2SourcesDir.groovy
@@ -31,7 +31,9 @@ class InitJaxb2SourcesDir extends DefaultTask {
 
     for (XjcTaskConfig theConfig : xjcConfigs) {
       File generatedSourcesDir = project.file(theConfig.generatedSourcesDir)
-      verifyNotWithinMainBuildSrc(generatedSourcesDir)
+      if (theConfig.createSourceSet) {
+        verifyNotWithinMainBuildSrc(generatedSourcesDir)
+      }
       createSourcesDirectory(generatedSourcesDir)
     }
   }

--- a/jaxb2-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/XjcTaskConfig.groovy
+++ b/jaxb2-plugin/src/main/groovy/com/ewerk/gradle/plugins/tasks/XjcTaskConfig.groovy
@@ -18,6 +18,7 @@ class XjcTaskConfig {
   String includedBindingFiles
   String encoding = 'UTF-8'
   String additionalArgs = ''
+  boolean createSourceSet = true
   boolean extension = false
 
   XjcTaskConfig(String name) {


### PR DESCRIPTION
This adds a property to the `XjcTaskConfig` for skipping the generation of the JAXB2 sourceSet.

Suitable for when your project is nothing but xjc generated classes.

Closes #124