### PR TITLE
don't create jaxb2 configuration if it already exists

### DIFF
--- a/jaxb2-plugin/src/main/groovy/com/ewerk/gradle/plugins/Jaxb2Plugin.groovy
+++ b/jaxb2-plugin/src/main/groovy/com/ewerk/gradle/plugins/Jaxb2Plugin.groovy
@@ -50,7 +50,7 @@ class Jaxb2Plugin implements Plugin<Project> {
   }
 
   private static Configuration addJaxb2Configuration(Project project) {
-    project.configurations.create('jaxb2')
+    project.configurations.maybeCreate('jaxb2')
   }
 
   private static void addJaxb2Extension(Project project) {


### PR DESCRIPTION
Currently I have a case where I need the classpath for the xjc task to be a specific one, with this I can create the configuration myself and make sure of the order.

(This is the first PR of a few)